### PR TITLE
Support Fluent-bit Forwarding

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/logger_fluentd_backend.ex
+++ b/lib/logger_fluentd_backend.ex
@@ -9,7 +9,7 @@ defmodule LoggerFluentdBackend do
     children = [
       # Define workers and child supervisors to be supervised
       {LoggerFluentdBackend.Sender, []}
-     ]
+    ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/logger_fluentd_backend/logger.ex
+++ b/lib/logger_fluentd_backend/logger.ex
@@ -61,34 +61,43 @@ defmodule LoggerFluentdBackend.Logger do
     tag = Keyword.get(config, :tag) || ""
     level = Keyword.get(config, :level)
     # metadata = Keyword.get(config, :metadata, [])
+    # Extra fields to emit with the log payload
+    extra_fields = Keyword.get(config, :extra_fields, %{})
 
     # Configure Sender state as well
-    Sender.configure(host: host, port: port, serializer: serializer)
+    Sender.configure(host: host, port: port, serializer: serializer, extra_fields: extra_fields)
 
-    %{level: level, host: host, port: port, tag: tag, serializer: serializer}
+    %{level: level, tag: tag}
   end
 
   defp configure_merge(env, options) do
     Keyword.merge(env, options, fn _, _v1, v2 -> v2 end)
   end
 
-  defp log_event(level, msg, _ts, md, %{tag: tag} = state) do
+  defp log_event(level, msg, _ts, md, %{tag: tag}) do
     f =
       case md[:function] do
         {f, a} -> "#{f}/#{a}"
         _ -> ""
       end
 
+    # TODO(ttaylor) Re-add module? Check w/ maintainer
+    filename =
+      md
+      |> Keyword.get(:file, "")
+      |> Path.rootname()
+      |> Path.basename()
+
     data = %{
       pid: inspect(md[:pid]),
-      module: inspect(md[:module]),
+      filename: filename,
       function: f,
-      line: inspect(md[:module]),
+      line: inspect(md[:line]),
       level: to_string(level),
       message: to_string(msg),
       payload: md[:payload]
     }
 
-    Sender.send(tag, data, state.host, state.port, state.serializer)
+    Sender.send(tag, data)
   end
 end

--- a/lib/logger_fluentd_backend/logger.ex
+++ b/lib/logger_fluentd_backend/logger.ex
@@ -48,6 +48,8 @@ defmodule LoggerFluentdBackend.Logger do
   ## Helpers
 
   defp meet_level?(_lvl, nil), do: true
+  # Somewhere deep in the deps, something is using deprecated :warn level. Don't let them
+  defp meet_level?(:warn, _), do: false
   defp meet_level?(lvl, min), do: Logger.compare_levels(lvl, min) != :lt
 
   defp configure(options) do

--- a/lib/logger_fluentd_backend/logger.ex
+++ b/lib/logger_fluentd_backend/logger.ex
@@ -62,6 +62,9 @@ defmodule LoggerFluentdBackend.Logger do
     level = Keyword.get(config, :level)
     # metadata = Keyword.get(config, :metadata, [])
 
+    # Configure Sender state as well
+    Sender.configure(host: host, port: port, serializer: serializer)
+
     %{level: level, host: host, port: port, tag: tag, serializer: serializer}
   end
 

--- a/lib/logger_fluentd_backend/sender.ex
+++ b/lib/logger_fluentd_backend/sender.ex
@@ -55,7 +55,6 @@ defmodule LoggerFluentdBackend.Sender do
   end
 
   def handle_cast({:send, tag, data, options}, %State{socket: socket} = state) do
-    tag = "pattern.logs.#{tag}"
     # Fluent-bit expects an EXT type for Forward input timestamp (10-bytes, w/ 4B epoch
     # seconds and 4B ns)
     now = now()
@@ -74,7 +73,7 @@ defmodule LoggerFluentdBackend.Sender do
 
     # Insert D7 (fixext 8), 00 (integer type), and time (2-part integer).
     # spec for ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats
-    # NOTE: must be big-endian (elixir kernel default)
+    # NOTE: must be big-endian (elixir bitstring default)
     time_bitstring =
       <<0xD7, 0x00>> <> <<now_s::unsigned-size(32)>> <> <<now_ns::unsigned-size(32)>>
 

--- a/lib/logger_fluentd_backend/sender.ex
+++ b/lib/logger_fluentd_backend/sender.ex
@@ -11,6 +11,7 @@ defmodule LoggerFluentdBackend.Sender do
               host: nil,
               port: nil,
               serializer: nil,
+              extra_fields: %{},
               connection_failure_warned: false
   end
 
@@ -53,6 +54,10 @@ defmodule LoggerFluentdBackend.Sender do
     GenServer.start_link(__MODULE__, [], name: __MODULE__)
   end
 
+  def handle_cast({:configure, options}, state) do
+    {:noreply, construct_state(state.socket, options, state.connection_failure_warned)}
+  end
+
   def handle_cast({_, _, _, options} = msg, %State{socket: nil} = state) do
     options = resolve_options(options, state)
 
@@ -65,37 +70,9 @@ defmodule LoggerFluentdBackend.Sender do
     end
   end
 
-  def handle_cast({:configure, opts}, state) do
-    {:noreply, construct_state(state.socket, opts, state.connection_failure_warned)}
-  end
-
   def handle_cast({:send, tag, data, options}, %State{socket: socket} = state) do
     options = resolve_options(options, state)
-    # Fluent-bit expects an EXT type for Forward input timestamp (10-bytes, w/ 4B epoch
-    # seconds and 4B ns)
-    now = now()
-
-    {now_s, now_ms} =
-      now
-      |> Decimal.from_float()
-      |> Decimal.div_rem(1)
-
-    now_s = Decimal.to_integer(now_s)
-
-    now_ns =
-      now_ms
-      |> Decimal.mult(1_000_000)
-      |> Decimal.to_integer()
-
-    # Insert D7 (fixext 8), 00 (integer type), and time (2-part integer).
-    # spec for ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats
-    # NOTE: must be big-endian (elixir bitstring default)
-    time_bitstring =
-      <<0xD7, 0x00>> <> <<now_s::unsigned-size(32)>> <> <<now_ns::unsigned-size(32)>>
-
-    time_binary = Msgpax.unpack!(time_bitstring)
-    payload = [tag, time_binary, data]
-
+    payload = construct_payload(tag, data, options[:extra_fields])
     packet = serializer(options[:serializer]).(payload)
     Stream.send!(socket, packet)
     {:noreply, state}
@@ -130,10 +107,46 @@ defmodule LoggerFluentdBackend.Sender do
     host = options[:host] || Map.get(state, :host, "localhost")
     port = options[:port] || Map.get(state, :port, 24224)
     serializer = options[:serializer] || Map.get(state, :serializer, :msgpack)
-    [host: host, port: port, serializer: serializer]
+    extra_fields = options[:extra_fields] || state.extra_fields
+
+    [host: host, port: port, serializer: serializer, extra_fields: extra_fields]
   end
 
-  # Helper to construct the servevr state with the correct fields
+  defp construct_payload(tag, data, extra_fields) do
+    # Fluent-bit expects an EXT type for Forward input timestamp (10-bytes, w/ 4B epoch
+    # seconds and 4B ns)
+    now = now()
+
+    {now_s, now_ms} =
+      now
+      |> Decimal.from_float()
+      |> Decimal.div_rem(1)
+
+    now_s = Decimal.to_integer(now_s)
+
+    now_ns =
+      now_ms
+      |> Decimal.mult(1_000_000)
+      |> Decimal.to_integer()
+
+    # Insert D7 (fixext 8), 00 (integer type), and time (2-part integer).
+    # spec for ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats
+    # NOTE: must be big-endian (elixir bitstring default)
+    time_bitstring =
+      <<0xD7, 0x00>> <> <<now_s::unsigned-size(32)>> <> <<now_ns::unsigned-size(32)>>
+
+    time_binary = Msgpax.unpack!(time_bitstring)
+
+    # Merge in configured extra fields with data payload
+    data = Map.merge(extra_fields, data)
+    [tag, time_binary, data]
+  end
+
+  defp serializer(:msgpack), do: &Msgpax.pack!/1
+  defp serializer(:json), do: &Jason.encode!/1
+  defp serializer(f) when is_function(f, 1), do: f
+
+  # Helper to construct the server state with the expected fields
   @spec construct_state(TCP.t() | nil, keyword(), boolean()) :: %State{}
   defp construct_state(socket, options, failure_warning) do
     %State{
@@ -141,13 +154,10 @@ defmodule LoggerFluentdBackend.Sender do
       connection_failure_warned: failure_warning,
       host: options[:host],
       port: options[:port],
-      serializer: options[:serializer]
+      serializer: options[:serializer],
+      extra_fields: Keyword.get(options, :extra_fields, %{})
     }
   end
-
-  defp serializer(:msgpack), do: &Msgpax.pack!/1
-  defp serializer(:json), do: &Jason.encode!/1
-  defp serializer(f) when is_function(f, 1), do: f
 
   defp now() do
     {megasec, sec, usec} = :os.timestamp()

--- a/lib/logger_fluentd_backend/sender.ex
+++ b/lib/logger_fluentd_backend/sender.ex
@@ -54,10 +54,10 @@ defmodule LoggerFluentdBackend.Sender do
     end
   end
 
-  def handle_cast({:send, _tag, _data, options}, %State{socket: socket} = state) do
-    # DEBUG
-    tag = "a tag"
-    data = %{}
+  def handle_cast({:send, tag, data, options}, %State{socket: socket} = state) do
+    tag = "pattern.logs.#{tag}"
+    # Fluent-bit expects an EXT type for Forward input timestamp (10-bytes, w/ 4B epoch
+    # seconds and 4B ns)
     now = now()
 
     {now_s, now_ms} =
@@ -72,28 +72,31 @@ defmodule LoggerFluentdBackend.Sender do
       |> Decimal.mult(1_000_000)
       |> Decimal.to_integer()
 
+    # Insert D7 (fixext 8), 00 (integer type), and time (2-part integer).
+    # spec for ref: https://github.com/msgpack/msgpack/blob/master/spec.md#formats
+    # NOTE: must be big-endian (elixir kernel default)
     time_bitstring =
       <<0xD7, 0x00>> <> <<now_s::unsigned-size(32)>> <> <<now_ns::unsigned-size(32)>>
 
-    IO.inspect(print_binary(time_bitstring))
-    IO.inspect(print_binary(Msgpax.pack!(now)))
-
     time_binary = Msgpax.unpack!(time_bitstring)
-    IO.inspect(time_binary)
-    candidate_payload = [tag, time_binary, data]
-    candidate_packet = serializer(options[:serializer]).(candidate_payload, iodata: false)
-    IO.puts("Candidate packet: \t#{inspect(print_binary(candidate_packet))}")
-    payload = [tag, now, data]
-    packet = serializer(options[:serializer]).(payload, iodata: false)
+    payload = [tag, time_binary, data]
+
+    packet = serializer(options[:serializer]).(payload)
     Stream.send!(socket, packet)
-    # IO.puts("Data: #{inspect(payload)}")
-    IO.puts("Sent packet \t\t#{inspect(print_binary(packet))}")
     {:noreply, state}
   end
 
   defp print_binary(bitstring) do
     for(<<x::size(1) <- bitstring>>, do: "#{x}")
     |> Enum.chunk_every(8)
+    |> Enum.join(" ")
+  end
+
+  defp print_hex(bitstring) do
+    bitstring
+    |> Base.encode16()
+    |> String.graphemes()
+    |> Enum.chunk_every(2)
     |> Enum.join(" ")
   end
 
@@ -118,7 +121,7 @@ defmodule LoggerFluentdBackend.Sender do
     end
   end
 
-  defp serializer(:msgpack), do: &Msgpax.pack!/2
+  defp serializer(:msgpack), do: &Msgpax.pack!/1
   defp serializer(:json), do: &Jason.encode!/1
   defp serializer(f) when is_function(f, 1), do: f
 

--- a/lib/logger_fluentd_backend/sender.ex
+++ b/lib/logger_fluentd_backend/sender.ex
@@ -54,10 +54,47 @@ defmodule LoggerFluentdBackend.Sender do
     end
   end
 
-  def handle_cast({:send, tag, data, options}, %State{socket: socket} = state) do
-    packet = serializer(options[:serializer]).([tag, now(), data])
+  def handle_cast({:send, _tag, _data, options}, %State{socket: socket} = state) do
+    # DEBUG
+    tag = "a tag"
+    data = %{}
+    now = now()
+
+    {now_s, now_ms} =
+      now
+      |> Decimal.from_float()
+      |> Decimal.div_rem(1)
+
+    now_s = Decimal.to_integer(now_s)
+
+    now_ns =
+      now_ms
+      |> Decimal.mult(1_000_000)
+      |> Decimal.to_integer()
+
+    time_bitstring =
+      <<0xD7, 0x00>> <> <<now_s::unsigned-size(32)>> <> <<now_ns::unsigned-size(32)>>
+
+    IO.inspect(print_binary(time_bitstring))
+    IO.inspect(print_binary(Msgpax.pack!(now)))
+
+    time_binary = Msgpax.unpack!(time_bitstring)
+    IO.inspect(time_binary)
+    candidate_payload = [tag, time_binary, data]
+    candidate_packet = serializer(options[:serializer]).(candidate_payload, iodata: false)
+    IO.puts("Candidate packet: \t#{inspect(print_binary(candidate_packet))}")
+    payload = [tag, now, data]
+    packet = serializer(options[:serializer]).(payload, iodata: false)
     Stream.send!(socket, packet)
+    # IO.puts("Data: #{inspect(payload)}")
+    IO.puts("Sent packet \t\t#{inspect(print_binary(packet))}")
     {:noreply, state}
+  end
+
+  defp print_binary(bitstring) do
+    for(<<x::size(1) <- bitstring>>, do: "#{x}")
+    |> Enum.chunk_every(8)
+    |> Enum.join(" ")
   end
 
   # Try to connect a socket, returning the state with the resulting socket if successful
@@ -81,12 +118,12 @@ defmodule LoggerFluentdBackend.Sender do
     end
   end
 
-  defp serializer(:msgpack), do: &Msgpax.pack!/1
+  defp serializer(:msgpack), do: &Msgpax.pack!/2
   defp serializer(:json), do: &Jason.encode!/1
   defp serializer(f) when is_function(f, 1), do: f
 
   defp now() do
-    {msec, sec, _} = :os.timestamp()
-    msec * 1_000_000 + sec
+    {megasec, sec, usec} = :os.timestamp()
+    megasec * 1_000_000 + sec + usec / 1_000_000
   end
 end

--- a/lib/logger_fluentd_backend/sender.ex
+++ b/lib/logger_fluentd_backend/sender.ex
@@ -8,6 +8,9 @@ defmodule LoggerFluentdBackend.Sender do
 
   defmodule State do
     defstruct socket: nil,
+              host: nil,
+              port: nil,
+              serializer: nil,
               connection_failure_warned: false
   end
 
@@ -19,12 +22,18 @@ defmodule LoggerFluentdBackend.Sender do
     {:ok, %State{socket: nil}}
   end
 
-  def send(tag, data, host, port, serializer) do
+  def configure(options) do
+    :ok = GenServer.cast(__MODULE__, {:configure, options})
+  end
+
+  def send(tag, data) do
+    :ok = GenServer.cast(__MODULE__, {:send, tag, data, []})
+  end
+
+  def send(tag, data, host, port, serializer \\ :msgpack) do
     options = [host: host, port: port, serializer: serializer]
     :ok = GenServer.cast(__MODULE__, {:send, tag, data, options})
   end
-
-  def send(tag, data, host, port), do: send(tag, data, host, port, :msgpack)
 
   def stop() do
     GenServer.call(__MODULE__, {:stop, []})
@@ -45,6 +54,8 @@ defmodule LoggerFluentdBackend.Sender do
   end
 
   def handle_cast({_, _, _, options} = msg, %State{socket: nil} = state) do
+    options = resolve_options(options, state)
+
     case connect(options, state) do
       %State{socket: nil} = state ->
         {:noreply, state}
@@ -54,7 +65,12 @@ defmodule LoggerFluentdBackend.Sender do
     end
   end
 
+  def handle_cast({:configure, opts}, state) do
+    {:noreply, construct_state(state.socket, opts, state.connection_failure_warned)}
+  end
+
   def handle_cast({:send, tag, data, options}, %State{socket: socket} = state) do
+    options = resolve_options(options, state)
     # Fluent-bit expects an EXT type for Forward input timestamp (10-bytes, w/ 4B epoch
     # seconds and 4B ns)
     now = now()
@@ -85,29 +101,16 @@ defmodule LoggerFluentdBackend.Sender do
     {:noreply, state}
   end
 
-  defp print_binary(bitstring) do
-    for(<<x::size(1) <- bitstring>>, do: "#{x}")
-    |> Enum.chunk_every(8)
-    |> Enum.join(" ")
-  end
-
-  defp print_hex(bitstring) do
-    bitstring
-    |> Base.encode16()
-    |> String.graphemes()
-    |> Enum.chunk_every(2)
-    |> Enum.join(" ")
-  end
-
   # Try to connect a socket, returning the state with the resulting socket if successful
   @spec connect(keyword(), %State{}) :: %State{}
-  defp connect(options, %{connection_failure_warned: warned}) do
-    host = options[:host] || "localhost"
-    port = options[:port] || 24224
+  defp connect(options, %{connection_failure_warned: warned} = state) do
+    options = resolve_options(options, state)
+    host = options[:host]
+    port = options[:port]
 
     case TCP.connect(host, port, packet: 0) do
       {:ok, socket} ->
-        %State{socket: socket, connection_failure_warned: false}
+        construct_state(socket, options, false)
 
       {:error, err} ->
         if not warned do
@@ -116,8 +119,30 @@ defmodule LoggerFluentdBackend.Sender do
           )
         end
 
-        %State{socket: nil, connection_failure_warned: true}
+        construct_state(nil, options, true)
     end
+  end
+
+  # Use explicitly passed options; or configured values in state if not specified; or
+  # fall back to default values
+  @spec resolve_options(keyword(), %State{}) :: keyword()
+  defp resolve_options(options, state) do
+    host = options[:host] || Map.get(state, :host, "localhost")
+    port = options[:port] || Map.get(state, :port, 24224)
+    serializer = options[:serializer] || Map.get(state, :serializer, :msgpack)
+    [host: host, port: port, serializer: serializer]
+  end
+
+  # Helper to construct the servevr state with the correct fields
+  @spec construct_state(TCP.t() | nil, keyword(), boolean()) :: %State{}
+  defp construct_state(socket, options, failure_warning) do
+    %State{
+      socket: socket,
+      connection_failure_warned: failure_warning,
+      host: options[:host],
+      port: options[:port],
+      serializer: options[:serializer]
+    }
   end
 
   defp serializer(:msgpack), do: &Msgpax.pack!/1

--- a/lib/logger_fluentd_backend/sender.ex
+++ b/lib/logger_fluentd_backend/sender.ex
@@ -113,6 +113,7 @@ defmodule LoggerFluentdBackend.Sender do
   end
 
   defp construct_payload(tag, data, extra_fields) do
+    tag = construct_tag(tag, data)
     # Fluent-bit expects an EXT type for Forward input timestamp (10-bytes, w/ 4B epoch
     # seconds and 4B ns)
     now = now()
@@ -141,6 +142,15 @@ defmodule LoggerFluentdBackend.Sender do
     data = Map.merge(extra_fields, data)
     [tag, time_binary, data]
   end
+
+  def construct_tag(tag, %{level: log_level}) when is_binary(log_level) do
+    case tag do
+      "" -> log_level
+      tag when is_binary(tag) -> "#{tag}.#{log_level}"
+    end
+  end
+
+  def construct_tag(tag, _data), do: tag
 
   defp serializer(:msgpack), do: &Msgpax.pack!/1
   defp serializer(:json), do: &Jason.encode!/1

--- a/lib/logger_fluentd_backend/sender.ex
+++ b/lib/logger_fluentd_backend/sender.ex
@@ -4,11 +4,14 @@ defmodule LoggerFluentdBackend.Sender do
   alias Socket.Stream
   alias Socket.TCP
 
+  require Logger
+
   defmodule State do
-    defstruct socket: nil
+    defstruct socket: nil,
+              connection_failure_warned: false
   end
 
-  def start_link([])do
+  def start_link([]) do
     GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
   end
 
@@ -31,7 +34,9 @@ defmodule LoggerFluentdBackend.Sender do
     {:reply, :ok, %State{socket: nil}}
   end
 
-  def terminate(_reason, %State{socket: socket}) when not is_nil(socket) do
+  def terminate(_reason, %State{socket: nil}), do: :ok
+
+  def terminate(_reason, %State{socket: socket}) do
     Stream.close(socket)
   end
 
@@ -40,8 +45,13 @@ defmodule LoggerFluentdBackend.Sender do
   end
 
   def handle_cast({_, _, _, options} = msg, %State{socket: nil} = state) do
-    socket = connect(options)
-    handle_cast(msg, %State{state | socket: socket})
+    case connect(options, state) do
+      %State{socket: nil} = state ->
+        {:noreply, state}
+
+      state ->
+        handle_cast(msg, state)
+    end
   end
 
   def handle_cast({:send, tag, data, options}, %State{socket: socket} = state) do
@@ -50,12 +60,25 @@ defmodule LoggerFluentdBackend.Sender do
     {:noreply, state}
   end
 
-  defp connect(options) do
-    TCP.connect!(
-      options[:host] || "localhost",
-      options[:port] || 24224,
-      packet: 0
-    )
+  # Try to connect a socket, returning the state with the resulting socket if successful
+  @spec connect(keyword(), %State{}) :: %State{}
+  defp connect(options, %{connection_failure_warned: warned}) do
+    host = options[:host] || "localhost"
+    port = options[:port] || 24224
+
+    case TCP.connect(host, port, packet: 0) do
+      {:ok, socket} ->
+        %State{socket: socket, connection_failure_warned: false}
+
+      {:error, err} ->
+        if not warned do
+          Logger.error(
+            "Unable to connect TCP socket at #{host}:#{port} for fluent logger: #{err} "
+          )
+        end
+
+        %State{socket: nil, connection_failure_warned: true}
+    end
   end
 
   defp serializer(:msgpack), do: &Msgpax.pack!/1

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule LoggerFluentdBackend.Mixfile do
     [
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:msgpax, "~> 2.4"},
-      {:jason, "~> 1.1"},
+      {:jason, "~> 1.4"},
       {:socket, "~> 0.3"}
     ]
   end

--- a/test/logger_test.exs
+++ b/test/logger_test.exs
@@ -7,12 +7,16 @@ defmodule LoggerFluentdBackend.LoggerTest do
 
   setup do
     # Application.put_env(:logger, :backends, [LoggerFluentdBackend.Logger])
-    Application.put_env(:logger, :logger_fluentd_backend, host: @host, port: @port, serializer: :msgpack)
+    Application.put_env(:logger, :logger_fluentd_backend,
+      host: @host,
+      port: @port,
+      serializer: :msgpack
+    )
 
     Logger.add_backend(LoggerFluentdBackend.Logger, flush: true)
 
     Application.ensure_started(:logger)
-    
+
     MockFluentdServer.start(@port, self())
 
     :ok


### PR DESCRIPTION
## Overview
This PR contains changes required to forward to fluent-bit; primarily this entails a new msgpack format for the message timestamp, using a fixed EXT8 with the tag, timestamp, and data. I'm not sure if this format breaks compatibility with fluentd, or if that will accept this timestamp format as well. If not, I will break this new timestamp option out into a configurable behavior.

It also contains a number of additional configuration options for extra fields to include in the payload. This new functionality comes directly from my application I'm trying to integrate, as there are certain fixed metadata fields that we want to include with all logs (e.g. version tag) once they're evaluated at run-time.

## Testing
- [ ] Update unit tests to exercise additional functionality
- [x] Integration testing against a fluent-bit logging client, locally and in a kubernetes deployment
